### PR TITLE
✨ [FEAT] 메쉬 스코어 상위 100명 랭킹 조회, 나의 순위, 순위 user별 상세 프로필

### DIFF
--- a/Mesh_backend/build.gradle
+++ b/Mesh_backend/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.530'
+
 }
 
 tasks.named('test') {

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/controller/RankController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/controller/RankController.java
@@ -1,0 +1,51 @@
+package com.example.mesh_backend.rank.controller;
+
+import com.example.mesh_backend.rank.dto.UserRankResponseDTO;
+import com.example.mesh_backend.rank.service.RankService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/rank")
+@Tag(name = "Rank", description = "랭킹 관련 API")
+@RequiredArgsConstructor
+public class RankController {
+
+    private final RankService rankService;
+
+    @GetMapping
+    @Operation(summary = "랭킹 리스트 조회", description = "Mesh Score 기준으로 상위 100명의 랭킹을 반환합니다.")
+    public ResponseEntity<List<UserRankResponseDTO>> getRankList() {
+        List<UserRankResponseDTO> rankList = rankService.getTop100UsersByMeshScore();
+        return ResponseEntity.ok(rankList);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "나의 랭킹 조회", description = "현재 사용자의 랭킹을 조회합니다.")
+    public ResponseEntity<UserRankResponseDTO> getMyRank(@RequestHeader("Authorization") String token) {
+        // Token에서 userId 추출 (TokenService 활용)
+        Long userId = extractUserIdFromToken(token);
+        UserRankResponseDTO userRank = rankService.getUserRank(userId);
+        return ResponseEntity.ok(userRank);
+    }
+
+    @GetMapping("/{user_id}")
+    @Operation(summary = "특정 사용자 랭킹 조회", description = "특정 사용자의 랭킹을 조회합니다.")
+    public ResponseEntity<UserRankResponseDTO> getUserRank(@PathVariable("user_id") Long userId) {
+        UserRankResponseDTO userRank = rankService.getUserRank(userId);
+        return ResponseEntity.ok(userRank);
+    }
+
+    // 토큰에서 userId 추출 메서드 (TokenService 활용)
+    private Long extractUserIdFromToken(String token) {
+        String accessToken = token.replace("Bearer ", "");
+        // TokenService의 메서드를 사용하여 userId 추출
+        // return tokenService.getUserFromAccessToken(accessToken).getUserId();
+        return 1L; // 예제용으로 1L 반환
+    }
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/controller/RankController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/controller/RankController.java
@@ -1,5 +1,6 @@
 package com.example.mesh_backend.rank.controller;
 
+import com.example.mesh_backend.rank.dto.UserProfileResponseDTO;
 import com.example.mesh_backend.rank.dto.UserRankResponseDTO;
 import com.example.mesh_backend.rank.service.RankService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,27 +19,28 @@ public class RankController {
 
     private final RankService rankService;
 
+    // 상위 100명 랭킹 조회
     @GetMapping
     @Operation(summary = "랭킹 리스트 조회", description = "Mesh Score 기준으로 상위 100명의 랭킹을 반환합니다.")
-    public ResponseEntity<List<UserRankResponseDTO>> getRankList() {
+    public ResponseEntity<List<UserRankResponseDTO>> getTopRankList() {
         List<UserRankResponseDTO> rankList = rankService.getTop100UsersByMeshScore();
         return ResponseEntity.ok(rankList);
     }
 
+    // 나의 랭킹 조회
     @GetMapping("/me")
-    @Operation(summary = "나의 랭킹 조회", description = "현재 사용자의 랭킹을 조회합니다.")
+    @Operation(summary = "나의 랭킹 조회", description = "현재 사용자의 Mesh Score 순위를 반환합니다.")
     public ResponseEntity<UserRankResponseDTO> getMyRank(@RequestHeader("Authorization") String token) {
-        // Token에서 userId 추출 (TokenService 활용)
-        Long userId = extractUserIdFromToken(token);
+        Long userId = extractUserIdFromToken(token); // 토큰에서 userId 추출
         UserRankResponseDTO userRank = rankService.getUserRank(userId);
         return ResponseEntity.ok(userRank);
     }
 
     @GetMapping("/{user_id}")
-    @Operation(summary = "특정 사용자 랭킹 조회", description = "특정 사용자의 랭킹을 조회합니다.")
-    public ResponseEntity<UserRankResponseDTO> getUserRank(@PathVariable("user_id") Long userId) {
-        UserRankResponseDTO userRank = rankService.getUserRank(userId);
-        return ResponseEntity.ok(userRank);
+    @Operation(summary = "특정 사용자 프로필 조회", description = "특정 사용자의 프로필을 조회합니다.")
+    public ResponseEntity<UserProfileResponseDTO> getUserProfile(@PathVariable("user_id") Long userId) {
+        UserProfileResponseDTO userProfile = rankService.getUserProfile(userId);
+        return ResponseEntity.ok(userProfile);
     }
 
     // 토큰에서 userId 추출 메서드 (TokenService 활용)

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/AwardResponseDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/AwardResponseDTO.java
@@ -1,0 +1,11 @@
+package com.example.mesh_backend.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AwardResponseDTO {
+    private String projectName;
+    private String result;
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/CareerResponseDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/CareerResponseDTO.java
@@ -1,0 +1,12 @@
+package com.example.mesh_backend.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CareerResponseDTO {
+    private String company;
+    private String position;
+    private String duration;
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/ToolResponseDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/ToolResponseDTO.java
@@ -1,0 +1,11 @@
+package com.example.mesh_backend.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ToolResponseDTO {
+    private String toolName;
+    private Integer proficiency; // 1~5 점수
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/UserProfileResponseDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/UserProfileResponseDTO.java
@@ -1,0 +1,21 @@
+package com.example.mesh_backend.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class UserProfileResponseDTO {
+    private Long userId;
+    private String nickname;
+    private Long meshScore;
+    private String major;
+    private String profileImageUrl;
+    private String content;
+    private List<String> subcategories; // 키워드
+    private List<AwardResponseDTO> awards;
+    private List<CareerResponseDTO> careers;
+    private List<ToolResponseDTO> tools;
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/UserRankResponseDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/UserRankResponseDTO.java
@@ -10,4 +10,5 @@ public class UserRankResponseDTO {
     private String nickname;
     private Long meshScore;
     private String profileImageUrl;
+    private Integer rank;
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/UserRankResponseDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/dto/UserRankResponseDTO.java
@@ -1,0 +1,13 @@
+package com.example.mesh_backend.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserRankResponseDTO {
+    private Long userId;
+    private String nickname;
+    private Long meshScore;
+    private String profileImageUrl;
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/repository/RankRepository.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/repository/RankRepository.java
@@ -1,0 +1,16 @@
+package com.example.mesh_backend.rank.repository;
+
+import com.example.mesh_backend.login.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RankRepository extends JpaRepository<User, Long> {
+
+    // mesh_score를 기준으로 정렬하여 상위 100명 조회
+    @Query("SELECT u FROM User u ORDER BY u.meshScore DESC")
+    List<User> findTop100ByOrderByMeshScoreDesc();
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/repository/RankRepository.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/repository/RankRepository.java
@@ -13,4 +13,5 @@ public interface RankRepository extends JpaRepository<User, Long> {
     // mesh_score를 기준으로 정렬하여 상위 100명 조회
     @Query("SELECT u FROM User u ORDER BY u.meshScore DESC")
     List<User> findTop100ByOrderByMeshScoreDesc();
+    int countByMeshScoreGreaterThan(Long meshScore);
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/service/RankService.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/service/RankService.java
@@ -1,7 +1,7 @@
 package com.example.mesh_backend.rank.service;
 
 import com.example.mesh_backend.login.entity.User;
-import com.example.mesh_backend.rank.dto.UserRankResponseDTO;
+import com.example.mesh_backend.rank.dto.*;
 import com.example.mesh_backend.rank.repository.RankRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ public class RankService {
 
     private final RankRepository rankRepository;
 
-    // 상위 100명의 사용자 랭킹 조회
+    // 상위 100명의 사용자 조회
     public List<UserRankResponseDTO> getTop100UsersByMeshScore() {
         List<User> topUsers = rankRepository.findTop100ByOrderByMeshScoreDesc();
         return topUsers.stream()
@@ -23,14 +23,72 @@ public class RankService {
                         user.getUserId(),
                         user.getNickname(),
                         user.getMeshScore(),
-                        user.getProfileImageUrl()
+                        user.getProfileImageUrl(),
+                        null // 순위는 별도로 반환하지 않음
                 ))
                 .collect(Collectors.toList());
     }
 
-    // 특정 사용자 랭킹 조회
+    // 나의 랭킹 조회
     public UserRankResponseDTO getUserRank(Long userId) {
-        User user = rankRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-        return new UserRankResponseDTO(user.getUserId(), user.getNickname(), user.getMeshScore(), user.getProfileImageUrl());
+        // 1. 현재 사용자의 정보 조회
+        User user = rankRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 2. 현재 사용자의 Mesh Score로 순위 계산
+        Long userScore = user.getMeshScore();
+        int rank = rankRepository.countByMeshScoreGreaterThan(userScore) + 1;
+
+        // 3. UserRankResponseDTO 반환 (순위 포함)
+        return new UserRankResponseDTO(
+                user.getUserId(),
+                user.getNickname(),
+                user.getMeshScore(),
+                user.getProfileImageUrl(),
+                rank
+        );
+    }
+
+    // 특정 사용자 랭킹 세부 조회
+    public UserProfileResponseDTO getUserProfile(Long userId) {
+        User user = rankRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // Subcategories
+        List<String> subcategories = user.getMaincategories().stream()
+                .flatMap(maincategory -> maincategory.getSubcategories().stream())
+                .map(subcategory -> subcategory.getSubcategoryName().toString())
+                .collect(Collectors.toList());
+
+        // Awards
+        List<AwardResponseDTO> awards = user.getAwards().stream()
+                .map(award -> new AwardResponseDTO(award.getProjectName(), award.getResult()))
+                .collect(Collectors.toList());
+
+        // Careers
+        List<CareerResponseDTO> careers = user.getCareers().stream()
+                .map(career -> new CareerResponseDTO(
+                        career.getCompany(),
+                        career.getPosition(),
+                        career.getDuration()))
+                .collect(Collectors.toList());
+
+        // Tools
+        List<ToolResponseDTO> tools = user.getTools().stream()
+                .map(tool -> new ToolResponseDTO(tool.getToolName(), tool.getProficiency()))
+                .collect(Collectors.toList());
+
+        return new UserProfileResponseDTO(
+                user.getUserId(),
+                user.getNickname(),
+                user.getMeshScore(),
+                user.getMajor(),
+                user.getProfileImageUrl(),
+                user.getContent(),
+                subcategories,
+                awards,
+                careers,
+                tools
+        );
     }
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/rank/service/RankService.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/rank/service/RankService.java
@@ -1,0 +1,36 @@
+package com.example.mesh_backend.rank.service;
+
+import com.example.mesh_backend.login.entity.User;
+import com.example.mesh_backend.rank.dto.UserRankResponseDTO;
+import com.example.mesh_backend.rank.repository.RankRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RankService {
+
+    private final RankRepository rankRepository;
+
+    // 상위 100명의 사용자 랭킹 조회
+    public List<UserRankResponseDTO> getTop100UsersByMeshScore() {
+        List<User> topUsers = rankRepository.findTop100ByOrderByMeshScoreDesc();
+        return topUsers.stream()
+                .map(user -> new UserRankResponseDTO(
+                        user.getUserId(),
+                        user.getNickname(),
+                        user.getMeshScore(),
+                        user.getProfileImageUrl()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    // 특정 사용자 랭킹 조회
+    public UserRankResponseDTO getUserRank(Long userId) {
+        User user = rankRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return new UserRankResponseDTO(user.getUserId(), user.getNickname(), user.getMeshScore(), user.getProfileImageUrl());
+    }
+}


### PR DESCRIPTION
## 연관 이슈

- #14 

## 📁 작업 내용

메쉬 스코어를 기준으로 상위 100명을 오름차순으로 정렬하여 보냄
나의 순위는 따로 api로 독립적 호출이 가능하도록 함.
userid request로 올 시 상세 프로필을 볼 수 있도록 함.

## 📁 기타 사항
