### PR TITLE
[feat] 팀구인완료시 자동으로 팀채팅 생성 api 구현

### DIFF
--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/MemberDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/MemberDTO.java
@@ -1,0 +1,8 @@
+package com.example.mesh_backend.chat.dto;
+
+import lombok.Data;
+
+@Data
+public class MemberDTO {
+    private String nickname;
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/TeamMembersDTO.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/TeamMembersDTO.java
@@ -1,0 +1,13 @@
+package com.example.mesh_backend.chat.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TeamMembersDTO {
+    private List<MemberDTO> pmMembers;
+    private List<MemberDTO> backMembers;
+    private List<MemberDTO> frontMembers;
+    private List<MemberDTO> designMembers;
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/ChatRoom.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/ChatRoom.java
@@ -28,6 +28,9 @@ public class ChatRoom {
     @Column(nullable = false)
     private String roomName;
 
+    @Enumerated(EnumType.STRING)
+    private ChatRoomType chatRoomType;
+
     @ManyToOne
     @JoinColumn(name = "creator_id")
     private User creator; // 채팅방을 생성한 유저
@@ -42,9 +45,10 @@ public class ChatRoom {
     @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)
     private List<Schedule> schedules;
 
-    public ChatRoom(String roomName, User creator, Long postId) {
+    public ChatRoom(String roomName, User creator, Long postId, ChatRoomType chatRoomType) {
         this.roomName = roomName;
         this.creator = creator;
         this.postId = postId;
+        this.chatRoomType = chatRoomType;
     }
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/ChatRoomType.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/ChatRoomType.java
@@ -1,0 +1,6 @@
+package com.example.mesh_backend.chat.entity;
+
+public enum ChatRoomType {
+    일대일,
+    팀
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/respository/ChatroomRepository.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/respository/ChatroomRepository.java
@@ -1,6 +1,7 @@
 package com.example.mesh_backend.chat.respository;
 
 import com.example.mesh_backend.chat.entity.ChatRoom;
+import com.example.mesh_backend.chat.entity.ChatRoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,6 @@ public interface ChatroomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findOneToOneChatRoomByPost(@Param("userId1") Long userId1,
                                                   @Param("userId2") Long userId2,
                                                   @Param("postId") Long postId);
+
+    Optional<ChatRoom> findByPostIdAndChatRoomType(Long postId, ChatRoomType chatRoomType);
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/common/exception/ErrorCode.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     KAKAO_API_ERROR(500, "KAKAO001", "카카오 API 호출 중 오류가 발생했습니다."),
     JSON_PARSING_ERROR(400, "COMMON001", "JSON 파싱 오류 발생"),
     UNKNOWN_ERROR(500, "COMMON003", "처리 중 오류 발생"),
+    IO_ERROR(500,"IMAGE001","입출력 오류발생"),
 
 
 

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/login/controller/UserController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/login/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.mesh_backend.login.controller;
 
+import com.example.mesh_backend.common.CustomException;
 import com.example.mesh_backend.common.exception.ErrorCode;
 import com.example.mesh_backend.common.utils.S3Uploader;
 import com.example.mesh_backend.login.dto.request.KakaoSignupRequest;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpHeaders;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,6 +37,7 @@ import java.util.Optional;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/api/v1/auth")
 @Tag(name = "카카오 Oauth", description = "카카오 Oauth API")
 public class UserController {
@@ -80,7 +83,17 @@ public class UserController {
             UserIdResponse responseData = new UserIdResponse(user.getUserId());
             return ResponseEntity.ok(BasicResponse.ofSuccess(responseData));
 
+        } catch (CustomException e) {
+            // 사용자 정의 예외 처리
+            log.error("CustomException 발생: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(BasicResponse.ofError(e.getErrorCode()));
+        } catch (IOException e) {
+            // 파일 다운로드 또는 업로드 예외 처리
+            log.error("I/O 예외 발생: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.IO_ERROR));
         } catch (Exception e) {
+            // 기타 알 수 없는 예외 처리
+            log.error("알 수 없는 오류 발생: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.INTERNAL_SERVER_ERROR));
         }
     }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/login/entity/Maincategory.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/login/entity/Maincategory.java
@@ -27,6 +27,6 @@ public class Maincategory {
     @Enumerated(EnumType.STRING)
     private MainCategoryName maincategoryName;
 
-    @OneToMany(mappedBy = "maincategory", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "maincategory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Subcategory> subcategories;
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/login/entity/User.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/login/entity/User.java
@@ -62,5 +62,4 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Career> careers;
 
-
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/login/repository/UserRepository.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/login/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.example.mesh_backend.login.repository;
 
 import com.example.mesh_backend.login.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,7 +11,10 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
     Optional<User> findByUserId(Long userId);
-    User findByNickname(String nickname);
+
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/login/service/UserService.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/login/service/UserService.java
@@ -103,15 +103,15 @@ public class UserService {
 
     // 회원가입 (카카오에서 받은 정보를 DB에 저장)
     public User signup(User user) {
-        validateNickname(user.getNickname()); //중복 닉네임 예외처리
         return userRepository.save(user);
     }
 
     public void validateNickname(String nickname) {
-        if (userRepository.findByNickname(nickname) != null) {
+        if (userRepository.findByNickname(nickname).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
         }
     }
+
 
     public void logout(String accessToken) {
         String url = "https://kapi.kakao.com/v1/user/logout";
@@ -182,7 +182,6 @@ public class UserService {
     public void updateUser(User user) {
         userRepository.save(user);
     }
-
 
 
     @Transactional

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/controller/MypageController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/controller/MypageController.java
@@ -1,11 +1,17 @@
 package com.example.mesh_backend.mypage.controller;
 
 import com.example.mesh_backend.common.exception.ErrorCode;
+import com.example.mesh_backend.login.entity.SubCategoryName;
+import com.example.mesh_backend.login.entity.Subcategory;
 import com.example.mesh_backend.login.entity.User;
 import com.example.mesh_backend.login.security.CustomUserDetails;
 import com.example.mesh_backend.login.service.UserService;
 import com.example.mesh_backend.message.BasicResponse;
+import com.example.mesh_backend.mypage.dto.request.AwardRequest;
+import com.example.mesh_backend.mypage.dto.request.CareerRequest;
+import com.example.mesh_backend.mypage.dto.request.ToolRequest;
 import com.example.mesh_backend.mypage.dto.request.UserProfileRequest;
+import com.example.mesh_backend.mypage.dto.response.UserProfileResponse;
 import com.example.mesh_backend.mypage.service.MeshScoreService;
 import com.example.mesh_backend.mypage.service.MypageService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -18,12 +24,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
@@ -39,7 +45,7 @@ public class MypageController {
     //1. 내 정보 수정
     @PatchMapping(value = "/profile/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "프로필 수정 및 이미지 업데이트", description = "내 정보와 프로필 이미지를 수정하는 API")
-    public ResponseEntity<BasicResponse<String>> updateProfile(
+    public ResponseEntity<BasicResponse<UserProfileResponse>> updateProfile(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestPart(value = "userUpdateRequest", required = false) String userUpdateRequestJson,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
@@ -51,12 +57,14 @@ public class MypageController {
         User user = customUserDetails.getUser();
 
         try {
+            // 업데이트 요청 처리
             if (userUpdateRequestJson != null && !userUpdateRequestJson.isEmpty()) {
                 ObjectMapper objectMapper = new ObjectMapper();
                 UserProfileRequest request = objectMapper.readValue(userUpdateRequestJson, UserProfileRequest.class);
                 mypageService.updateUserProfile(user, request);
             }
 
+            // 프로필 이미지 업데이트
             if (profileImage != null && !profileImage.isEmpty()) {
                 String newImageUrl = userService.updateUserProfileImage(user, profileImage);
                 user.setProfileImageUrl(newImageUrl);
@@ -65,16 +73,104 @@ public class MypageController {
             // 메시 스코어 계산
             meshScoreService.calculateAndSaveMeshScore(user.getUserId());
 
-            return ResponseEntity.ok(BasicResponse.ofSuccess("프로필 수정 및 이미지 업데이트 완료"));
+            // 응답 데이터 생성
+            UserProfileResponse response = new UserProfileResponse(
+                    user.getUserId(),
+                    user.getNickname(),
+                    user.getMeshScore(),
+                    user.getProfileImageUrl(),
+                    user.getMajor(),
+                    user.getContent(),
+                    user.getPortfolio(),
+                    user.getMaincategories().stream()
+                            .flatMap(mainCategory -> mainCategory.getSubcategories().stream())
+                            .map(Subcategory::getSubcategoryName)
+                            .collect(Collectors.toList()),
+                    user.getAwards().stream()
+                            .map(award -> new AwardRequest(
+                                    award.getProjectName(),
+                                    award.getPart(),
+                                    award.getResult(),
+                                    award.getScale()))
+                            .collect(Collectors.toList()),
+                    user.getCareers().stream()
+                            .map(career -> new CareerRequest(
+                                    career.getDuration(),
+                                    career.getCompany(),
+                                    career.getPosition()))
+                            .collect(Collectors.toList()),
+                    user.getTools().stream()
+                            .map(tool -> new ToolRequest(
+                                    tool.getToolName(),
+                                    tool.getProficiency()))
+                            .collect(Collectors.toList())
+            );
+
+            return ResponseEntity.ok(BasicResponse.ofSuccess(response));
         } catch (JsonProcessingException e) {
+            e.printStackTrace();
             return ResponseEntity.badRequest().body(BasicResponse.ofError(ErrorCode.JSON_PARSING_ERROR));
         } catch (IOException e) {
+            e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.FILE_PROCESSING_ERROR));
         } catch (IllegalArgumentException e) {
+            e.printStackTrace();
             return ResponseEntity.badRequest().body(BasicResponse.ofError(ErrorCode.DUPLICATE_NICKNAME));
         } catch (Exception e) {
+            e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.UNKNOWN_ERROR));
         }
     }
+
+    // 2. 내 프로필 조회
+    @GetMapping("/my/profile")
+    @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 프로필 정보를 조회하는 API")
+    public ResponseEntity<BasicResponse<UserProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        if (customUserDetails == null) {
+            return ResponseEntity.badRequest().body(BasicResponse.ofError(ErrorCode.UNAUTHORIZED_USER));
+        }
+
+        try {
+            Long userId = customUserDetails.getUser().getUserId();
+            UserProfileResponse response = mypageService.getUserProfile(userId);
+
+            return ResponseEntity.ok(BasicResponse.ofSuccess(response));
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return ResponseEntity.badRequest().body(BasicResponse.ofError(ErrorCode.USER_NOT_FOUND));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.UNKNOWN_ERROR));
+        }
+    }
+
+    // 3. 다른 사용자 프로필 조회
+    @GetMapping("/{userId}/profile")
+    @Operation(summary = "다른 사용자 프로필 조회", description = "다른 사용자의 프로필 정보를 조회하는 API")
+    public ResponseEntity<BasicResponse<UserProfileResponse>> getOtherUserProfile(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long userId) {
+
+        if (customUserDetails == null) {
+            return ResponseEntity.badRequest().body(BasicResponse.ofError(ErrorCode.UNAUTHORIZED_USER));
+        }
+
+        try {
+            // 다른 사용자의 프로필 조회
+            UserProfileResponse response = mypageService.getUserProfile(userId);
+
+            return ResponseEntity.ok(BasicResponse.ofSuccess(response));
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return ResponseEntity.badRequest().body(BasicResponse.ofError(ErrorCode.USER_NOT_FOUND));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.UNKNOWN_ERROR));
+        }
+    }
+
+
 
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/request/AwardRequest.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/request/AwardRequest.java
@@ -1,9 +1,13 @@
 package com.example.mesh_backend.mypage.dto.request;
 
 import com.example.mesh_backend.mypage.entity.Scale;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class AwardRequest {
     private String projectName;
     private String part;

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/request/CareerRequest.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/request/CareerRequest.java
@@ -1,8 +1,12 @@
 package com.example.mesh_backend.mypage.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class CareerRequest {
     private String duration;
     private String company;

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/request/ToolRequest.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/request/ToolRequest.java
@@ -1,8 +1,12 @@
 package com.example.mesh_backend.mypage.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ToolRequest {
     private String toolName;
     private int proficiency;

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/response/UserProfileResponse.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/dto/response/UserProfileResponse.java
@@ -1,0 +1,32 @@
+package com.example.mesh_backend.mypage.dto.response;
+
+import com.example.mesh_backend.login.entity.SubCategoryName;
+import com.example.mesh_backend.mypage.dto.request.AwardRequest;
+import com.example.mesh_backend.mypage.dto.request.CareerRequest;
+import com.example.mesh_backend.mypage.dto.request.ToolRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfileResponse {
+    private Long userId;
+    private String nickname;
+    private Long meshScore;
+    private String profileImageUrl;
+    private String major;
+    private String content;
+    private String portfolio;
+
+    private List<SubCategoryName> subCategories;
+
+    private List<AwardRequest> awards;
+    private List<CareerRequest> careers;
+    private List<ToolRequest> tools;
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/service/MypageService.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/mypage/service/MypageService.java
@@ -2,7 +2,11 @@ package com.example.mesh_backend.mypage.service;
 
 import com.example.mesh_backend.login.entity.*;
 import com.example.mesh_backend.login.repository.UserRepository;
+import com.example.mesh_backend.mypage.dto.request.AwardRequest;
+import com.example.mesh_backend.mypage.dto.request.CareerRequest;
+import com.example.mesh_backend.mypage.dto.request.ToolRequest;
 import com.example.mesh_backend.mypage.dto.request.UserProfileRequest;
+import com.example.mesh_backend.mypage.dto.response.UserProfileResponse;
 import com.example.mesh_backend.mypage.entity.Award;
 import com.example.mesh_backend.mypage.entity.Career;
 import com.example.mesh_backend.mypage.entity.CollaborationTool;
@@ -133,5 +137,44 @@ public class MypageService {
         }
 
         userRepository.save(user);
+    }
+
+
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        return new UserProfileResponse(
+                user.getUserId(),
+                user.getNickname(),
+                user.getMeshScore(),
+                user.getProfileImageUrl(),
+                user.getMajor(),
+                user.getContent(),
+                user.getPortfolio(),
+                user.getMaincategories().stream()
+                        .flatMap(mainCategory -> mainCategory.getSubcategories().stream())
+                        .map(Subcategory::getSubcategoryName)
+                        .collect(Collectors.toList()),
+                user.getAwards().stream()
+                        .map(award -> new AwardRequest(
+                                award.getProjectName(),
+                                award.getPart(),
+                                award.getResult(),
+                                award.getScale()))
+                        .collect(Collectors.toList()),
+                user.getCareers().stream()
+                        .map(career -> new CareerRequest(
+                                career.getDuration(),
+                                career.getCompany(),
+                                career.getPosition()))
+                        .collect(Collectors.toList()),
+                user.getTools().stream()
+                        .map(tool -> new ToolRequest(
+                                tool.getToolName(),
+                                tool.getProficiency()))
+                        .collect(Collectors.toList())
+        );
     }
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/post/controller/PostController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/post/controller/PostController.java
@@ -27,7 +27,7 @@ public class PostController {
         this.tokenService = tokenService;
     }
 
-    @PostMapping
+    @PostMapping()
     @Operation(
             summary = "공고 등록 API",
             description = "사용자가 팀원을 모집하는 공고를 등록함."

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/post/repository/ProjectRepository.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/post/repository/ProjectRepository.java
@@ -5,7 +5,10 @@ import com.example.mesh_backend.post.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     void deleteAllByPost(Post post);
+    List<Project> findByPost(Post post);
 }


### PR DESCRIPTION
## 연관 이슈

- #이슈번호
- #21 

## 📁 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요.

- "모집완료" 시 팀 단체 톡방 생성 기능 구현
- mypage를 통해 내 프로필, 다른 유저프로필 볼 수 있는 기능 구현

## 📁 기타 사항
