### PR TITLE
[feat] 팀 지원시 개인채팅방 생성

### DIFF
--- a/Mesh_backend/src/main/java/com/example/mesh_backend/apply/service/ApplyServiceImpl.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/apply/service/ApplyServiceImpl.java
@@ -3,11 +3,15 @@ package com.example.mesh_backend.apply.service;
 import com.example.mesh_backend.apply.dto.ApplyRequestDTO;
 import com.example.mesh_backend.apply.entity.Apply;
 import com.example.mesh_backend.apply.repository.ApplyRepository;
+import com.example.mesh_backend.chat.entity.ChatRoom;
+import com.example.mesh_backend.chat.respository.MessageRepository;
+import com.example.mesh_backend.chat.service.ChatService;
 import com.example.mesh_backend.common.CustomException;
 import com.example.mesh_backend.common.exception.ErrorCode;
 import com.example.mesh_backend.login.entity.User;
 import com.example.mesh_backend.post.entity.Post;
 import com.example.mesh_backend.post.repository.PostRepository;
+import com.example.mesh_backend.chat.entity.Message;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -17,10 +21,15 @@ public class ApplyServiceImpl implements ApplyService {
 
     private final ApplyRepository applyRepository;
     private final PostRepository postRepository;
+    private final ChatService chatService;
 
-    public ApplyServiceImpl(ApplyRepository applyRepository, PostRepository postRepository) {
+    private final MessageRepository messageRepository;
+    public ApplyServiceImpl(ApplyRepository applyRepository, PostRepository postRepository,
+                            ChatService chatService, MessageRepository messageRepository){
         this.applyRepository = applyRepository;
         this.postRepository = postRepository;
+        this.chatService = chatService;
+        this.messageRepository = messageRepository;
     }
 
     @Override
@@ -39,6 +48,29 @@ public class ApplyServiceImpl implements ApplyService {
         apply.setLeaderId(post.getUser().getUserId());
 
         applyRepository.save(apply);
-        return "지원이 완료되었습니다.";
+
+
+        //일대일 채팅방 생성
+        ChatRoom chatRoom = chatService.createOrGetOneToOneChatRoom(
+                user.getUserId(), post.getUser().getUserId(), projectId
+        );
+
+        String userProfileUrl = "/api/v1/user/" + user.getUserId() + "/profile";
+
+        // 자동 메시지 생성 및 전송
+        String autoMessage = "[" + applyRequestDTO.getPart() + "]\n"
+                + user.getNickname() + "님이 "
+                + "\"" + post.getPostTitle() + "\" 모집 공고에 지원했습니다.\n"
+                + "(전달 메시지: " + applyRequestDTO.getContents() + ")\n"
+                + "지원자 프로필 보기: " + userProfileUrl;
+
+        Message message = new Message();
+        message.setChatRoom(chatRoom);
+        message.setUser(user);
+        message.setContent(autoMessage);
+        messageRepository.save(message);
+
+
+        return "지원이 성공적으로 완료되었습니다.";
     }
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/controller/ChatScheduleController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/controller/ChatScheduleController.java
@@ -2,8 +2,10 @@ package com.example.mesh_backend.chat.controller;
 
 import com.example.mesh_backend.chat.dto.request.ScheduleCreateRequest;
 import com.example.mesh_backend.chat.dto.request.ScheduleUpdateRequest;
+import com.example.mesh_backend.chat.dto.response.ScheduleListResponse;
 import com.example.mesh_backend.chat.dto.response.ScheduleResponse;
 import com.example.mesh_backend.chat.service.ChatScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ public class ChatScheduleController {
 
     // 스케줄 생성
     @PostMapping
+    @Operation(summary = "채팅방 스케줄 생성", description = "채팅방 스케줄 생성 API")
     public ResponseEntity<ScheduleResponse> createSchedule(@RequestBody ScheduleCreateRequest request) {
         ScheduleResponse schedule = chatScheduleService.createSchedule(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(schedule);
@@ -26,11 +29,22 @@ public class ChatScheduleController {
 
     // 스케줄 수정
     @PatchMapping("/{scheduleId}")
+    @Operation(summary = "채팅방 스케줄 수정", description = "채팅방 스케줄 수정 API")
     public ResponseEntity<ScheduleResponse> updateSchedule(
             @PathVariable Long scheduleId,
             @RequestBody ScheduleUpdateRequest request) {
         ScheduleResponse updatedSchedule = chatScheduleService.updateSchedule(scheduleId, request);
         return ResponseEntity.ok(updatedSchedule);
     }
+
+    //특정 채팅방 스케줄 목록 확인
+    @GetMapping("/{chatRoomId}")
+    @Operation(summary = "채팅방 스케줄 목록", description = "채팅방 스케줄 목록 API")
+    public ResponseEntity<ScheduleListResponse> getSchedulesByChatRoom(@PathVariable("chatRoomId") Long chatRoomId) {
+        ScheduleListResponse scheduleListResponse = chatScheduleService.getSchedulesByChatRoom(chatRoomId);
+        return ResponseEntity.ok(scheduleListResponse);
+    }
+
+
 
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/controller/MessageController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/controller/MessageController.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 
@@ -25,15 +27,21 @@ public class MessageController {
     //메세지 송신
     @PostMapping("/send")
     @Operation(summary = "메세지 송신", description = "채팅방에 메세지 송신하는 API")
-    public ResponseEntity<MessageResponse> sendMessage(@RequestBody MessageRequest messageRequest) {
-        Message message = messageService.saveMessage(
-                messageRequest.getUserId(),
-                messageRequest.getChatRoomId(),
-                messageRequest.getContent()
-        );
-        return ResponseEntity.ok(MessageResponse.fromEntity(message));
+    public ResponseEntity<MessageResponse> sendMessage(
+            @RequestPart("messageRequest") MessageRequest messageRequest,
+            @RequestPart(value = "attachment", required = false) MultipartFile attachment) {
+        try {
+            Message message = messageService.saveMessage(
+                    messageRequest.getUserId(),
+                    messageRequest.getChatRoomId(),
+                    messageRequest.getContent(),
+                    attachment
+            );
+            return ResponseEntity.ok(MessageResponse.fromEntity(message));
+        } catch (IOException e) {
+            throw new RuntimeException("파일 업로드 중 오류가 발생했습니다.", e);
+        }
     }
-
 
     //메세지 수신
     @GetMapping("/recieve")

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/request/ChatSettingsUpdateRequest.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/request/ChatSettingsUpdateRequest.java
@@ -11,4 +11,5 @@ public class ChatSettingsUpdateRequest {
 
     private String notionLink;
     private String githubLink;
+    private String figmaLink;
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/ChatSettingsResponse.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/ChatSettingsResponse.java
@@ -13,6 +13,7 @@ public class ChatSettingsResponse {
     private Long chatRoomId;
     private String notionLink;
     private String githubLink;
+    private String figmaLink;
     private List<ParticipantResponse> participants;
     private ScheduleResponse nextSchedule;
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/MessageResponse.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/MessageResponse.java
@@ -14,6 +14,7 @@ public class MessageResponse {
     private String content;
     private String senderNickname;
     private String senderProfileUrl;
+    private String attachmentUrl;
     private LocalDateTime createdAt;
 
     public static MessageResponse fromEntity(Message message) {
@@ -23,6 +24,7 @@ public class MessageResponse {
                 message.getContent(),
                 message.getUser().getNickname(),
                 message.getUser().getProfileImageUrl(),
+                message.getAttachmentUrl(),
                 message.getCreatedAt()
         );
     }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/ScheduleListResponse.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/ScheduleListResponse.java
@@ -1,0 +1,22 @@
+package com.example.mesh_backend.chat.dto.response;
+
+import com.example.mesh_backend.chat.entity.Schedule;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ScheduleListResponse {
+    private Long chatRoomId;
+    private List<ScheduleResponse> schedules;
+
+    public static ScheduleListResponse of(Long chatRoomId, List<Schedule> scheduleList) {
+        List<ScheduleResponse> scheduleResponses = scheduleList.stream()
+                .map(ScheduleResponse::of)
+                .toList();
+
+        return new ScheduleListResponse(chatRoomId, scheduleResponses);
+    }
+}

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/ScheduleResponse.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/dto/response/ScheduleResponse.java
@@ -1,5 +1,6 @@
 package com.example.mesh_backend.chat.dto.response;
 
+import com.example.mesh_backend.chat.entity.Schedule;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,26 @@ import java.time.LocalTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ScheduleResponse {
+    private Long scheduleId;
+    private Long chatRoomId;
+    private String description;
     private LocalDate date;
     private LocalTime time;
-    private String description;
+
+    public ScheduleResponse(LocalDate date, LocalTime time, String description) {
+        this.date = date;
+        this.time = time;
+        this.description = description;
+    }
+
+
+    public static ScheduleResponse of(Schedule schedule) {
+        return new ScheduleResponse(
+                schedule.getId(),
+                schedule.getChatRoom().getId(),
+                schedule.getDescription(),
+                schedule.getDate(),
+                schedule.getTime()
+        );
+    }
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/ChatRoom.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/ChatRoom.java
@@ -42,6 +42,8 @@ public class ChatRoom {
 
     private String githubLink;
 
+    private String figmaLink;
+
     @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)
     private List<Schedule> schedules;
 

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/Message.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/Message.java
@@ -2,13 +2,11 @@ package com.example.mesh_backend.chat.entity;
 
 import com.example.mesh_backend.login.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 @Getter
+@Setter
 @Entity
 @Builder
 @NoArgsConstructor
@@ -24,6 +22,8 @@ public class Message {
     private User user;
 
     private String content;
+
+    private String attachmentUrl; // 첨부파일 URL
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id", nullable = false)

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/Schedule.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/entity/Schedule.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -26,4 +27,10 @@ public class Schedule {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
+
+    @Transient // DB에 저장하지 않고 런타임에서만 사용
+    public LocalDateTime getDateTime() {
+        return LocalDateTime.of(date, time);
+    }
+
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/respository/ScheduleRepository.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/respository/ScheduleRepository.java
@@ -3,11 +3,33 @@ package com.example.mesh_backend.chat.respository;
 import com.example.mesh_backend.chat.entity.ChatRoom;
 import com.example.mesh_backend.chat.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     Schedule findTopByChatRoomAndDateAfterOrderByDateAsc(ChatRoom chatRoom, LocalDate currentDate);
+
+    @Query("SELECT s FROM Schedule s WHERE s.chatRoom = :chatRoom AND (s.date < :currentDate OR (s.date = :currentDate AND s.time < :currentTime))")
+    List<Schedule> findByChatRoomAndDateTimeBefore(
+            @Param("chatRoom") ChatRoom chatRoom,
+            @Param("currentDate") LocalDate currentDate,
+            @Param("currentTime") LocalTime currentTime
+    );
+
+    @Query("SELECT s FROM Schedule s WHERE s.chatRoom = :chatRoom AND (s.date > :currentDate OR (s.date = :currentDate AND s.time >= :currentTime)) ORDER BY s.date ASC, s.time ASC")
+    List<Schedule> findByChatRoomAndDateTimeAfterOrderByDateTimeAsc(
+            @Param("chatRoom") ChatRoom chatRoom,
+            @Param("currentDate") LocalDate currentDate,
+            @Param("currentTime") LocalTime currentTime
+    );
+
+
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/service/ChatSettingsService.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/service/ChatSettingsService.java
@@ -3,6 +3,7 @@ package com.example.mesh_backend.chat.service;
 import com.example.mesh_backend.chat.dto.request.ChatSettingsUpdateRequest;
 import com.example.mesh_backend.chat.dto.response.ChatSettingsResponse;
 import com.example.mesh_backend.chat.dto.response.ParticipantResponse;
+import com.example.mesh_backend.chat.dto.response.ScheduleListResponse;
 import com.example.mesh_backend.chat.dto.response.ScheduleResponse;
 import com.example.mesh_backend.chat.entity.ChatRoom;
 import com.example.mesh_backend.chat.entity.Schedule;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +39,9 @@ public class ChatSettingsService {
         }
         if (request.getGithubLink() != null) {
             chatRoom.setGithubLink(request.getGithubLink());
+        }
+        if (request.getFigmaLink() != null) {
+            chatRoom.setFigmaLink(request.getFigmaLink());
         }
 
         ChatRoom updatedChatRoom = chatroomRepository.save(chatRoom);
@@ -64,6 +69,7 @@ public class ChatSettingsService {
                 chatRoom.getId(),
                 chatRoom.getNotionLink(),
                 chatRoom.getGithubLink(),
+                chatRoom.getFigmaLink(),
                 participants,
                 scheduleResponse
         );
@@ -100,8 +106,12 @@ public class ChatSettingsService {
                 chatRoom.getId(),
                 chatRoom.getNotionLink(),
                 chatRoom.getGithubLink(),
+                chatRoom.getFigmaLink(),
                 participants,
                 scheduleResponse
         );
     }
+
+
+
 }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/chat/service/MessageService.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/chat/service/MessageService.java
@@ -6,12 +6,15 @@ import com.example.mesh_backend.chat.entity.Message;
 import com.example.mesh_backend.chat.respository.ChatroomRepository;
 import com.example.mesh_backend.chat.respository.JoinChatRepository;
 import com.example.mesh_backend.chat.respository.MessageRepository;
+import com.example.mesh_backend.common.utils.S3Uploader;
 import com.example.mesh_backend.login.entity.User;
 import com.example.mesh_backend.login.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,29 +27,39 @@ public class MessageService {
     private final UserRepository userRepository;
     private final ChatroomRepository chatroomRepository;
     private final JoinChatRepository joinChatRepository;
+    private final S3Uploader s3Uploader;
 
     /**
      * 메시지 저장
      */
     @Transactional
-    public Message saveMessage(Long userId, Long chatRoomId, String content) {
+    public Message saveMessage(Long userId, Long chatRoomId, String content, MultipartFile attachment) throws IOException {
+        // 유저 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
 
+        // 채팅방 조회
         ChatRoom chatRoom = chatroomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new RuntimeException("채팅방을 찾을 수 없습니다."));
 
+        // 첨부파일 업로드
+        String attachmentUrl = null;
+        if (attachment != null && !attachment.isEmpty()) {
+            attachmentUrl = s3Uploader.uploadFiles(attachment, "chat");
+        }
+
+        // 메시지 생성
         Message message = Message.builder()
                 .user(user)
                 .chatRoom(chatRoom)
                 .content(content)
+                .attachmentUrl(attachmentUrl)
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        System.out.println("message 저장 : " + message);
-
         return messageRepository.save(message);
     }
+
 
     public Long getLatestMessageId(Long chatRoomId) {
         return messageRepository.findFirstByChatRoomIdOrderByIdDesc(chatRoomId)
@@ -82,6 +95,7 @@ public class MessageService {
                         message.getContent(),
                         message.getUser().getNickname(),
                         message.getUser().getProfileImageUrl(),
+                        message.getAttachmentUrl(),
                         message.getCreatedAt()))
                 .collect(Collectors.toList());
     }

--- a/Mesh_backend/src/main/java/com/example/mesh_backend/login/controller/UserController.java
+++ b/Mesh_backend/src/main/java/com/example/mesh_backend/login/controller/UserController.java
@@ -84,15 +84,12 @@ public class UserController {
             return ResponseEntity.ok(BasicResponse.ofSuccess(responseData));
 
         } catch (CustomException e) {
-            // 사용자 정의 예외 처리
             log.error("CustomException 발생: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(BasicResponse.ofError(e.getErrorCode()));
         } catch (IOException e) {
-            // 파일 다운로드 또는 업로드 예외 처리
             log.error("I/O 예외 발생: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.IO_ERROR));
         } catch (Exception e) {
-            // 기타 알 수 없는 예외 처리
             log.error("알 수 없는 오류 발생: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BasicResponse.ofError(ErrorCode.INTERNAL_SERVER_ERROR));
         }


### PR DESCRIPTION
## 연관 이슈

- #이슈번호
#27 
## 📁 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 팀공고보고 지원하기 누르면 개인 채팅방 생성및 자기 PR 개인 톡방으로 보내지는 기능 구현
-  스케줄관련해서 목록화하는거 추가해놓기
- 팀 셋팅에 노션, 깃허브, 피그마 링크 추가해놓기 
- 메세지 첨부파일 넣는 것 구현

## 📁 기타 사항
